### PR TITLE
Use caret dependency ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "lib/RenderKid.js",
   "dependencies": {
     "css-select": "^1.1.0",
-    "dom-converter": "~0.2",
-    "htmlparser2": "~3.3.0",
+    "dom-converter": "^0.2",
+    "htmlparser2": "^3.3.0",
     "strip-ansi": "^3.0.0",
     "utila": "^0.4.0"
   },


### PR DESCRIPTION
This allows all semver-compatible ranges of these dependencies to be installed, whereas `~` only allows for patches.

For example, `htmlparser2`'s latest release is 3.10.1, but `npm install renderkid` installs 3.3.0.

Thanks!