### PR TITLE
Reduce npm module size, bump node version on travis

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,6 @@ xeno
 
 sass
 .sass-cache
+
+.travis.yml
+test/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 
 node_js:
-  - 8.12.0
+  - 12.19.0
 
-sudo: false
+sudo: required


### PR DESCRIPTION
- `sudo: false` on travis was deprecated 2 years ago or so
- Update to v12 LTS on travis
- Don't include travis config or test files in production modules