### PR TITLE
Add support for disabling extra newlines

### DIFF
--- a/src/Layout.coffee
+++ b/src/Layout.coffee
@@ -3,6 +3,12 @@ Block = require './layout/Block'
 SpecialString = require './layout/SpecialString'
 terminalWidth = require('./tools').getCols()
 
+# Returns `true` when a line contains no text.
+# First regex removes whitespace.
+# Second regex removes HTML script tags.
+isEmptyLine = (line) ->
+  return line.replace(/\s/g, '').replace(/(<([^>]+)>)/ig, '') == ''
+
 module.exports = class Layout
   self = @
 
@@ -13,6 +19,7 @@ module.exports = class Layout
     blockAppendor: options: amount: 0
 
   @_defaultConfig:
+    extraNewlines: true
     terminalWidth: terminalWidth
 
   constructor: (config = {}, rootBlockConfig = {}) ->
@@ -32,12 +39,15 @@ module.exports = class Layout
     @_written.push text
 
   _appendLine: (text) ->
+    if !@_config.extraNewlines && isEmptyLine(text)
+      return this
+
     @_append text
     s = new SpecialString(text)
     if s.length < @_config.terminalWidth
       @_append '<none>\n</none>'
 
-    this
+    return this
 
   get: ->
     do @_ensureClosed

--- a/src/Layout.coffee
+++ b/src/Layout.coffee
@@ -3,12 +3,6 @@ Block = require './layout/Block'
 SpecialString = require './layout/SpecialString'
 terminalWidth = require('./tools').getCols()
 
-# Returns `true` when a line contains no text.
-# First regex removes whitespace.
-# Second regex removes HTML script tags.
-isEmptyLine = (line) ->
-  return line.replace(/\s/g, '').replace(/(<([^>]+)>)/ig, '') == ''
-
 module.exports = class Layout
   self = @
 
@@ -38,8 +32,14 @@ module.exports = class Layout
   _append: (text) ->
     @_written.push text
 
+  # Returns `true` when a line contains no text.
+  # First regex removes whitespace.
+  # Second regex removes HTML script tags.
+  _isEmptyLine: (line) ->
+    return line.replace(/\s/g, '').replace(/(<([^>]+)>)/ig, '') == ''
+
   _appendLine: (text) ->
-    if !@_config.extraNewlines && isEmptyLine(text)
+    if !@_config.extraNewlines && @_isEmptyLine(text)
       return this
 
     @_append text

--- a/src/RenderKid.coffee
+++ b/src/RenderKid.coffee
@@ -16,7 +16,10 @@ module.exports = class RenderKid
   @quote: tools.quote
   @tools: tools
   @_defaultConfig:
-    layout: {terminalWidth: terminalWidth}
+    layout: {
+      extraNewlines: true
+      terminalWidth: terminalWidth
+    }
 
   constructor: (config = {}) ->
     @tools = self.tools

--- a/test/Layout.coffee
+++ b/test/Layout.coffee
@@ -1,11 +1,38 @@
 Layout = require '../src/Layout'
 
+emptyLine = "<none>  </none>"
+nonEmptyLine = "<none>error</none>"
+
 describe "Layout", ->
   describe "constructor()", ->
     it "should create root block", ->
       l = new Layout
       expect(l._root).to.exist
       l._root._name.should.equal '__root'
+
+    it "should use extraNewlines:true by default", ->
+      l = new Layout
+      l._config.extraNewlines.should.equal true
+
+  describe "_isEmptyLine()", ->
+    it "should detect empty lines", ->
+      l = new Layout
+      l._isEmptyLine(emptyLine).should.equal true
+
+    it "should detect non-empty lines", ->
+      l = new Layout
+      l._isEmptyLine(nonEmptyLine).should.equal false
+
+  describe "_appendLine()", ->
+    it "should include extra newlines by default", ->
+      l = new Layout
+      l._appendLine(emptyLine)
+      l._written.length.should.equal 2
+
+    it "should exclude extra newlines when requested", ->
+      l = new Layout({ extraNewlines: false })
+      l._appendLine(emptyLine)
+      l._written.length.should.equal 0
 
   describe "get()", ->
     it "should not be allowed when any block is open", ->

--- a/test/RenderKid.coffee
+++ b/test/RenderKid.coffee
@@ -17,6 +17,10 @@ describe "RenderKid", ->
     it "should work", ->
       new RenderKid
 
+    it "should include extraNewlines:true in config", ->
+      r = new RenderKid
+      r._config.layout.extraNewlines.should.equal true
+
   describe "whitespace management - inline", ->
     it "shouldn't put extra whitespaces", ->
       input = """


### PR DESCRIPTION
This PR is a dependency of [AriaMinaei/pretty-error#68](https://github.com/AriaMinaei/pretty-error/pull/68), which partially resolves [AriaMinaei/pretty-error#67](https://github.com/AriaMinaei/pretty-error/issues/67).

Changes:

- Adds a new layout config key `extraNewlines`, which is set to `true` by default to preserve current behavior
- Updates `Layout._appendLine()` to skip printing empty lines when `extraNewlines` is set to `false`