### PR TITLE
Resolve vulnerability CVE-2021-3807

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dom-converter": "^0.2.0",
     "htmlparser2": "^6.1.0",
     "lodash": "^4.17.21",
-    "strip-ansi": "^6.0.1"
+    "strip-ansi": "^7.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.5",


### PR DESCRIPTION
Your `strip-ansi@6.0.1` uses a dependency called `ansi-regex@5.0.1` which has a vulnerability documented here:
https://security.snyk.io/vuln/SNYK-JS-ANSIREGEX-1583908

I upgraded your `strip-ansi` to latest version which uses a version where this vulnerability was fixed.